### PR TITLE
Update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ You can find documentation for the technologies behind the Civis workflows in
 the following spots:
 
 - [YAML](http://docs.ansible.com/ansible/latest/YAMLSyntax.html#yaml-basics)
-- [Mistral v2 Workflow DSL](https://docs.openstack.org/mistral/latest/user/dsl_v2.html)
+- [Mistral v2 Workflow DSL](https://docs.openstack.org/mistral/pike/user/dsl_v2.html)
 - [YAQL](https://yaql.readthedocs.io/en/latest/)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ The optimal order to read through them is
 You can find documentation for the technologies behind the Civis workflows in
 the following spots:
 
-- [YAML](http://docs.ansible.com/ansible/latest/YAMLSyntax.html#yaml-basics)
+- [YAML](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html)
 - [Mistral v2 Workflow DSL](https://docs.openstack.org/mistral/pike/user/dsl_v2.html)
 - [YAQL](https://yaql.readthedocs.io/en/latest/)

--- a/branching_and_dependencies.yml
+++ b/branching_and_dependencies.yml
@@ -9,7 +9,7 @@
 # See this website, http://docs.ansible.com/ansible/latest/YAMLSyntax.html#yaml-basics,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/latest/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL

--- a/branching_and_dependencies.yml
+++ b/branching_and_dependencies.yml
@@ -6,7 +6,7 @@
 # Workflows in the Civis Platform are written in YAML and a workflow DSL
 # (domain specific language) called Mistral.
 #
-# See this website, http://docs.ansible.com/ansible/latest/YAMLSyntax.html#yaml-basics,
+# See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
 # See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,

--- a/outputs_and_yaql.yml
+++ b/outputs_and_yaql.yml
@@ -7,7 +7,7 @@
 # See this website, http://docs.ansible.com/ansible/latest/YAMLSyntax.html#yaml-basics,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/latest/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
 # for a description of the Mistral DSL.
 #
 # See the YAQL docs for more details, https://yaql.readthedocs.io/en/latest/.

--- a/outputs_and_yaql.yml
+++ b/outputs_and_yaql.yml
@@ -4,7 +4,7 @@
 # Workflows in the Civis Platform are written in YAML and a workflow DSL
 # (domain specific language) called Mistral.
 #
-# See this website, http://docs.ansible.com/ansible/latest/YAMLSyntax.html#yaml-basics,
+# See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
 # See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,

--- a/pause.yml
+++ b/pause.yml
@@ -5,7 +5,7 @@
 # Workflows in the Civis Platform are written in YAML and a workflow DSL
 # (domain specific language) called Mistral.
 #
-# See this website, http://docs.ansible.com/ansible/latest/YAMLSyntax.html#yaml-basics,
+# See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
 # See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,

--- a/pause.yml
+++ b/pause.yml
@@ -8,7 +8,7 @@
 # See this website, http://docs.ansible.com/ansible/latest/YAMLSyntax.html#yaml-basics,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/latest/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL

--- a/quickstart.yml
+++ b/quickstart.yml
@@ -4,7 +4,7 @@
 # Workflows in the Civis Platform are written in YAML and a workflow DSL
 # (domain specific language) called Mistral.
 #
-# See this website, http://docs.ansible.com/ansible/latest/YAMLSyntax.html#yaml-basics,
+# See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
 # See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,

--- a/quickstart.yml
+++ b/quickstart.yml
@@ -1,5 +1,5 @@
-# This example workflow has one of each job type, demonstraing how to use
-# mistral to run some jobs on platfrom with "this-then-that" dependencies.
+# This example workflow has one of each job type, demonstrating how to use
+# mistral to run some jobs on platform with "this-then-that" dependencies.
 #
 # Workflows in the Civis Platform are written in YAML and a workflow DSL
 # (domain specific language) called Mistral.
@@ -7,7 +7,7 @@
 # See this website, http://docs.ansible.com/ansible/latest/YAMLSyntax.html#yaml-basics,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/latest/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL


### PR DESCRIPTION
Update the links to Mistral (broken) & YAML (redirects) documentation.