### PR TITLE
Add examples of passing parameters into scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,33 @@
-# Civis Mistral Examples
+# Civis Workflows Examples
 
-This directory contains several examples of how to use Mistral with the
-Civis Platform to execute workflows with complex job dependencies.
+This directory contains several examples of how to use Workflows in Civis Platform
+to execute workflows with complex job dependencies.
 
-## Quckstart
+## Quickstart
 
 The optimal order to read through them is
 
 1. `quickstart.yml`
 2. `branching_and_dependencies.yml`
 3. `outputs_and_yaql.yml`
-4. `pause.yml`
-5. `yaml_variables.yml`
-6. `variable_blocks.yml`
-5. `sql_script_jobs.yml`
-6. `custom_email_notifications.yml`
-7. `with_items.yml`
-8. `with_items_dict.yml`
-9. `automatic_task_retry.yml`
-10. `task_defaults.yml`
-11. `export.yml` 
+4. `sql_scripts.yml`
+5. `script_parameters.yml`
+6. `pause.yml`
+7. `yaml_variables.yml`
+8. `variable_blocks.yml`
+9. `custom_email_notifications.yml`
+10. `with_items.yml`
+11. `with_items_dict.yml`
+12. `automatic_task_retry.yml`
+13. `task_defaults.yml`
+14. `export.yml`
 
 ## Further Documentation
 
 You can find documentation for the technologies behind the Civis workflows in
 the following spots:
 
+- [Civis Workflows documentation](https://civis.zendesk.com/hc/en-us/articles/115004172983-Workflows-Basics)
+- [Mistral v2 Workflow DSL](https://docs.openstack.org/mistral/train/user/wf_lang_v2.html)
 - [YAML](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html)
-- [Mistral v2 Workflow DSL](https://docs.openstack.org/mistral/pike/user/dsl_v2.html)
 - [YAQL](https://yaql.readthedocs.io/en/latest/)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The optimal order to read through them is
 You can find documentation for the technologies behind the Civis workflows in
 the following spots:
 
-- [Civis Workflows documentation](https://civis.zendesk.com/hc/en-us/articles/115004172983-Workflows-Basics)
+- [Civis Workflows documentation](https://civis.zendesk.com/hc/en-us/articles/115004172983-Workflows-Basics) (requires Platform login)
 - [Mistral v2 Workflow DSL](https://docs.openstack.org/mistral/train/user/wf_lang_v2.html)
 - [YAML](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html)
 - [YAQL](https://yaql.readthedocs.io/en/latest/)

--- a/automatic_task_retry.yml
+++ b/automatic_task_retry.yml
@@ -6,7 +6,7 @@
 # See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/train/user/wf_lang_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL

--- a/branching_and_dependencies.yml
+++ b/branching_and_dependencies.yml
@@ -9,7 +9,7 @@
 # See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/train/user/wf_lang_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL

--- a/custom_email_notifications.yml
+++ b/custom_email_notifications.yml
@@ -7,7 +7,7 @@
 # See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/train/user/wf_lang_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL

--- a/export.yml
+++ b/export.yml
@@ -8,7 +8,7 @@
 # See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/train/user/wf_lang_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0' # you always need this key to specify version 2 of the mistral DSL

--- a/outputs_and_yaql.yml
+++ b/outputs_and_yaql.yml
@@ -7,7 +7,7 @@
 # See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/train/user/wf_lang_v2.html,
 # for a description of the Mistral DSL.
 #
 # See the YAQL docs for more details, https://yaql.readthedocs.io/en/latest/.

--- a/pause.yml
+++ b/pause.yml
@@ -8,7 +8,7 @@
 # See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/train/user/wf_lang_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL

--- a/quickstart.yml
+++ b/quickstart.yml
@@ -7,7 +7,7 @@
 # See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/train/user/wf_lang_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL

--- a/script_parameters.yml
+++ b/script_parameters.yml
@@ -106,7 +106,7 @@ workflow:
             type: credential_redshift
         arguments:
           my_custom_credential: 0  # ID of the credential
-          my_aws_credential: 0
+          my_aws_credential: 0     # get it from https://platform.civisanalytics.com/credentials
           my_db_credential: 0
         docker_command: |
           # Parameter values are added to your container as environment variables.
@@ -157,7 +157,7 @@ workflow:
             type: credential_redshift
         arguments:
           my_custom_credential: 0  # ID of the credential
-          my_aws_credential: 0
+          my_aws_credential: 0     # get it from https://platform.civisanalytics.com/credentials
           my_db_credential: 0
         source: |
           # Parameter values are added to your container as environment variables.
@@ -207,7 +207,7 @@ workflow:
           my_string: this is a string
           my_file: 0               # ID of the file
           my_custom_credential: 0  # ID of the credential
-          my_aws_credential: 0
+          my_aws_credential: 0     # get it from https://platform.civisanalytics.com/credentials
           my_db_credential: 0
         source: |
           # Parameter values are added to your container as environment variables.

--- a/script_parameters.yml
+++ b/script_parameters.yml
@@ -1,0 +1,191 @@
+# This example workflow demonstrates how to pass parameters into different types of scripts.
+#
+# Workflows in the Civis Platform are written in YAML and a workflow DSL
+# (domain specific language) called Mistral.
+#
+# See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
+# for an introduction to YAML.
+#
+# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
+# for a description of the Mistral DSL.
+
+version: '2.0'  # you always need this key to specify version 2 of the mistral DSL
+workflow:
+  tasks:
+    sql_script:
+      action: civis.scripts.sql
+      input:
+        remote_host_id: 0
+        credential_id: 0
+        params:
+          - name: my_boolean
+            type: bool
+            default: true
+          - name: my_integer
+            type: integer
+            default: 1234
+          - name: my_float
+            type: float
+            default: 0.1234
+          - name: my_string
+            type: string
+            default: this is a string
+          - name: my_custom_credential
+            type: credential_custom
+        arguments:
+          my_custom_credential: 0
+        sql: |
+          SELECT 1;
+          -- my_boolean: {{my_boolean}}
+          -- my_integer: {{my_integer}}
+          -- my_float: {{my_float}}
+          -- my_string: {{my_string.literal}}
+          -- my_custom_credential: {{my_custom_credential.username}} {{my_custom_credential.password}}
+      on-success:
+        - container_script
+    container_script:
+      action: civis.scripts.container
+      input:
+        docker_image_name: civisanalytics/datascience-python
+        required_resources:
+          cpu: 256
+          memory: 512
+          disk_space: 1
+        params:
+          - name: my_boolean
+            type: bool
+            default: true
+          - name: my_integer
+            type: integer
+            default: 1234
+          - name: my_float
+            type: float
+            default: 0.1234
+          - name: my_string
+            type: string
+            default: this is a string
+          - name: my_file
+            type: file
+            default: 0
+          - name: my_custom_credential
+            type: credential_custom
+          - name: my_aws_credential
+            type: credential_aws
+          - name: my_db_credential
+            type: credential_redshift
+        arguments:
+          my_custom_credential: 0
+          my_aws_credential: 0
+          my_db_credential: 0
+        docker_command: |
+          echo "my_boolean = $MY_BOOLEAN"
+          echo "my_integer = $MY_INTEGER"
+          echo "my_float = $MY_FLOAT"
+          echo "my_string = $MY_STRING_SHELL_ESCAPED"
+          echo "my_file is at $MY_FILE_URL"
+          # echo "my_custom_credential has username $MY_CUSTOM_CREDENTIAL_USERNAME, password $MY_CUSTOM_CREDENTIAL_PASSWORD"
+          # echo "my_aws_credential has access key id $MY_AWS_CREDENTIAL_ACCESS_KEY_ID, secret key $MY_AWS_CREDENTIAL_SECRET_ACCESS_KEY"
+          # echo "my_db_credential has username $MY_DB_CREDENTIAL_USERNAME, password $MY_DB_CREDENTIAL_PASSWORD"
+      on-success:
+        - python_script
+    python_script:
+      action: civis.scripts.python3
+      input:
+        required_resources:
+          cpu: 256
+          memory: 512
+          disk_space: 1
+        params:
+          - name: my_boolean
+            type: bool
+            default: true
+          - name: my_integer
+            type: integer
+            default: 1234
+          - name: my_float
+            type: float
+            default: 0.1234
+          - name: my_string
+            type: string
+            default: this is a string
+          - name: my_file
+            type: file
+            default: 0
+          - name: my_custom_credential
+            type: credential_custom
+          - name: my_aws_credential
+            type: credential_aws
+          - name: my_db_credential
+            type: credential_redshift
+        arguments:
+          my_custom_credential: 0
+          my_aws_credential: 0
+          my_db_credential: 0
+        source: |
+          import os
+
+          my_boolean = os.environ['MY_BOOLEAN'] == 'true'
+          my_integer = int(os.environ['MY_INTEGER'])
+          my_float = float(os.environ['MY_FLOAT'])
+
+          my_string = os.environ['MY_STRING']
+          my_file_url = os.environ['MY_FILE_URL']
+
+          my_custom_credential = (os.environ['MY_CUSTOM_CREDENTIAL_USERNAME'], os.environ['MY_CUSTOM_CREDENTIAL_PASSWORD'])
+          my_aws_credential = (os.environ['MY_AWS_CREDENTIAL_ACCESS_KEY_ID'], os.environ['MY_AWS_CREDENTIAL_SECRET_ACCESS_KEY'])
+          my_db_credential = (os.environ['MY_DB_CREDENTIAL_USERNAME'], os.environ['MY_DB_CREDENTIAL_PASSWORD'])
+      on-success:
+        - r_script
+    r_script:
+      action: civis.scripts.r
+      input:
+        required_resources:
+          cpu: 256
+          memory: 512
+          disk_space: 1
+        params:
+          - name: my_boolean
+            type: bool
+            default: true
+          - name: my_integer
+            type: integer
+            default: 1234
+          - name: my_float
+            type: float
+            default: 0.1234
+          - name: my_string
+            type: string
+            default: this is a string
+          - name: my_file
+            type: file
+            default: 0
+          - name: my_custom_credential
+            type: credential_custom
+          - name: my_aws_credential
+            type: credential_aws
+          - name: my_db_credential
+            type: credential_redshift
+        arguments:
+          my_custom_credential: 0
+          my_aws_credential: 0
+          my_db_credential: 0
+        source: |
+          my_boolean <- as.logical(Sys.getenv('MY_BOOLEAN'))
+          my_integer <- as.numeric(Sys.getenv('MY_INTEGER'))
+          my_float <- as.numeric(Sys.getenv('MY_FLOAT'))
+          my_string <- Sys.getenv('MY_STRING')
+          my_file_url <- Sys.getenv('MY_FILE_URL')
+          my_custom_credential_username <- Sys.getenv('MY_CUSTOM_CREDENTIAL_USERNAME')
+          my_custom_credential_password <- Sys.getenv('MY_CUSTOM_CREDENTIAL_PASSWORD')
+          my_aws_credential_access_key_id <- Sys.getenv('MY_AWS_CREDENTIAL_ACCESS_KEY_ID')
+          my_aws_credential_secret_access_key <- Sys.getenv('MY_AWS_CREDENTIAL_SECRET_ACCESS_KEY')
+          my_db_credential_username <- Sys.getenv('MY_DB_CREDENTIAL_USERNAME')
+          my_db_credential_password <- Sys.getenv('MY_DB_CREDENTIAL_PASSWORD')
+      on-success:
+        - custom_script
+    custom_script:
+      action: civis.scripts.custom
+      input:
+        from_template_id: 0
+        arguments:
+          branch_namme: blah

--- a/script_parameters.yml
+++ b/script_parameters.yml
@@ -1,13 +1,33 @@
-# This example workflow demonstrates how to pass parameters into different types of scripts.
+# This example workflow demonstrates how to pass parameters into different types
+# of scripts:
+#   1) SQL script
+#   2) Container script
+#   3) Python script
+#   4) R script
+#   5) Custom script
 #
-# Workflows in the Civis Platform are written in YAML and a workflow DSL
-# (domain specific language) called Mistral.
+# It generally involves adding a `params` list and an `arguments` hash to the
+# task inputs.  The `params` list defines the names and types of the parameters
+# that the script can take.  The `arguments` hash contains the values for those
+# parameters.  Think of it like a form, where `params` defines the checkboxes
+# and input fields on the form, and `arguments` is filling the form out.
 #
-# See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
-# for an introduction to YAML.
+# Currently, it is not possible to pass parameters from a workflow into an
+# existing script job (using the `civis.run_job` action).
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
-# for a description of the Mistral DSL.
+# Inside your script, parameter values are made available via templating (for
+# SQL scripts) or via environment variables (for Container, Python, and R
+# scripts).  See https://civis.zendesk.com/hc/en-us/articles/360001579592-Configuring-Scripts-via-the-Civis-API
+# for a reference of all the available parameter types and the variables made
+# available to your script.  If you are passing in string parameters from users
+# or untrusted sources, we advise using escaped versions of the variables to
+# prevent injection attacks.
+#
+# Links:
+# * Workflows documentation: https://civis.zendesk.com/hc/en-us/articles/115004172983-Workflows-Basics
+# * Script parameter reference: https://civis.zendesk.com/hc/en-us/articles/360001579592-Configuring-Scripts-via-the-Civis-API
+# * Mistral domain specific language reference: https://docs.openstack.org/mistral/latest/user/wf_lang_v2.html
+# * YAML syntax: https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL
 workflow:

--- a/script_parameters.yml
+++ b/script_parameters.yml
@@ -71,7 +71,7 @@ workflow:
           --   SELECT * FROM {{schema_name.identifier}}.{{table_name.identifier}}
           --     WHERE {{column_name.identifier}} > {{threshold}};
       on-success:
-        - container_script
+        - my_versatile_container_script
 
     my_versatile_container_script:
       action: civis.scripts.container
@@ -124,7 +124,7 @@ workflow:
         # appearing on the scripts index page, to reduce clutter.
         hidden: true
       on-success:
-        - python_script
+        - the_coolest_python_script
 
     the_coolest_python_script:
       action: civis.scripts.python3
@@ -177,7 +177,7 @@ workflow:
           my_aws_credential = (os.environ['MY_AWS_CREDENTIAL_ACCESS_KEY_ID'], os.environ['MY_AWS_CREDENTIAL_SECRET_ACCESS_KEY'])
           my_db_credential = (os.environ['MY_DB_CREDENTIAL_USERNAME'], os.environ['MY_DB_CREDENTIAL_PASSWORD'])
       on-success:
-        - r_script
+        - r_script_full_of_arrows
 
     r_script_full_of_arrows:
       action: civis.scripts.r
@@ -228,7 +228,7 @@ workflow:
           my_db_credential_username <- Sys.getenv('MY_DB_CREDENTIAL_USERNAME')
           my_db_credential_password <- Sys.getenv('MY_DB_CREDENTIAL_PASSWORD')
       on-success:
-        - custom_script
+        - my_convenient_custom_script
 
     my_convenient_custom_script:
       action: civis.scripts.custom

--- a/script_parameters.yml
+++ b/script_parameters.yml
@@ -124,6 +124,9 @@ workflow:
           # my_custom_credential generates $MY_CUSTOM_CREDENTIAL_USERNAME, $MY_CUSTOM_CREDENTIAL_PASSWORD
           # my_aws_credential generates $MY_AWS_CREDENTIAL_ACCESS_KEY_ID, $MY_AWS_CREDENTIAL_SECRET_ACCESS_KEY
           # my_db_credential generates $MY_DB_CREDENTIAL_USERNAME, $MY_DB_CREDENTIAL_PASSWORD
+        # You can add this if you want to prevent the created script from
+        # appearing on the scripts index page, to reduce clutter.
+        hidden: true
       on-success:
         - python_script
 

--- a/script_parameters.yml
+++ b/script_parameters.yml
@@ -66,6 +66,10 @@ workflow:
           -- {{my_string.identifier}} is in a format that is safe to be used as a Redshift identifier.
 
           -- my_custom_credential: {{my_custom_credential.username}} {{my_custom_credential.password}}
+
+          -- So, for example, you could use these variables in your SQL statements like
+          --   SELECT * FROM {{schema_name.identifier}}.{{table_name.identifier}}
+          --     WHERE {{column_name.identifier}} > {{threshold}};
       on-success:
         - container_script
 

--- a/script_parameters.yml
+++ b/script_parameters.yml
@@ -33,7 +33,7 @@
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL
 workflow:
   tasks:
-    sql_script:
+    my_awesome_sql_script:
       action: civis.scripts.sql
       input:
         # SQL scripts always require the IDs of the remote host and the credential
@@ -69,7 +69,7 @@ workflow:
       on-success:
         - container_script
 
-    container_script:
+    my_versatile_container_script:
       action: civis.scripts.container
       input:
         docker_image_name: civisanalytics/datascience-python
@@ -122,7 +122,7 @@ workflow:
       on-success:
         - python_script
 
-    python_script:
+    the_coolest_python_script:
       action: civis.scripts.python3
       input:
         required_resources:
@@ -175,7 +175,7 @@ workflow:
       on-success:
         - r_script
 
-    r_script:
+    r_script_full_of_arrows:
       action: civis.scripts.r
       input:
         required_resources:
@@ -226,7 +226,7 @@ workflow:
       on-success:
         - custom_script
 
-    custom_script:
+    my_convenient_custom_script:
       action: civis.scripts.custom
       input:
         # Custom scripts are built off of templates, which already define the

--- a/script_parameters.yml
+++ b/script_parameters.yml
@@ -41,8 +41,6 @@ workflow:
         remote_host_id: 0  # get it from https://api.civisanalytics.com/databases
         credential_id: 0   # get it from https://platform.civisanalytics.com/credentials
         params:  # This is not an exhaustive list of param types - see the script parameter reference for more
-          - name: my_boolean
-            type: bool
           - name: my_integer
             type: integer
           - name: my_float
@@ -52,7 +50,6 @@ workflow:
           - name: my_custom_credential
             type: credential_custom
         arguments:
-          my_boolean: true
           my_integer: 1234
           my_float: 0.1234
           my_string: this is a string
@@ -61,7 +58,6 @@ workflow:
           SELECT 1;
 
           -- Variables enclosed in double curly brackets will be replaced with the parameter values.
-          -- my_boolean: {{my_boolean}}
           -- my_integer: {{my_integer}}
           -- my_float: {{my_float}}
 
@@ -86,9 +82,6 @@ workflow:
           # Optionally, you can specify the parameter values in the `params` list
           # instead of in the `arguments` hash, by using the `default` key.  But
           # this does not work for credential parameters.
-          - name: my_boolean
-            type: bool
-            default: true
           - name: my_integer
             type: integer
             default: 1234
@@ -114,7 +107,6 @@ workflow:
         docker_command: |
           # Parameter values are added to your container as environment variables.
           # See the script params reference for a full list.
-          echo "my_boolean = $MY_BOOLEAN"
           echo "my_integer = $MY_INTEGER"
           echo "my_float = $MY_FLOAT"
           # To prevent command injection attacks, you can get shell-escaped versions of string parameters.
@@ -141,9 +133,6 @@ workflow:
           # Optionally, you can specify the parameter values in the `params` list
           # instead of in the `arguments` hash, by using the `default` key.  But
           # this does not work for credential parameters.
-          - name: my_boolean
-            type: bool
-            default: true
           - name: my_integer
             type: integer
             default: 1234
@@ -172,8 +161,8 @@ workflow:
 
           import os
 
-          # Type conversions are necessary.  Unfortunately, `bool()` does not work here.
-          my_boolean = os.environ['MY_BOOLEAN'] == 'true'
+          # Environment variables are retrieved as strings, so if you want to use
+          # them as numbers, you'll need to do type conversion.
           my_integer = int(os.environ['MY_INTEGER'])
           my_float = float(os.environ['MY_FLOAT'])
 
@@ -194,8 +183,6 @@ workflow:
           memory: 512
           disk_space: 1
         params:
-          - name: my_boolean
-            type: bool
           - name: my_integer
             type: integer
           - name: my_float
@@ -211,7 +198,6 @@ workflow:
           - name: my_db_credential
             type: credential_redshift
         arguments:
-          my_boolean: true
           my_integer: 1234
           my_float: 0.1234
           my_string: this is a string
@@ -223,8 +209,8 @@ workflow:
           # Parameter values are added to your container as environment variables.
           # See the script params reference for a full list.
 
-          # Type conversions are necessary.
-          my_boolean <- as.logical(Sys.getenv('MY_BOOLEAN'))
+          # Environment variables are retrieved as strings, so if you want to use
+          # them as numbers, you'll need to do type conversion.
           my_integer <- as.numeric(Sys.getenv('MY_INTEGER'))
           my_float <- as.numeric(Sys.getenv('MY_FLOAT'))
 

--- a/script_parameters.yml
+++ b/script_parameters.yml
@@ -220,7 +220,7 @@ workflow:
           # Parameter values are added to your container as environment variables.
           # See the script params reference for a full list.
 
-          # Type conversion are necessary.
+          # Type conversions are necessary.
           my_boolean <- as.logical(Sys.getenv('MY_BOOLEAN'))
           my_integer <- as.numeric(Sys.getenv('MY_INTEGER'))
           my_float <- as.numeric(Sys.getenv('MY_FLOAT'))

--- a/script_parameters.yml
+++ b/script_parameters.yml
@@ -13,15 +13,16 @@
 # and input fields on the form, and `arguments` is filling the form out.
 #
 # Currently, it is not possible to pass parameters from a workflow into an
-# existing script job (using the `civis.run_job` action).
+# existing script job (using the `civis.run_job` action).  Passing parameters
+# into a script will create a new job for each execution of the workflow.
 #
 # Inside your script, parameter values are made available via templating (for
 # SQL scripts) or via environment variables (for Container, Python, and R
 # scripts).  See https://civis.zendesk.com/hc/en-us/articles/360001579592-Configuring-Scripts-via-the-Civis-API
-# for a reference of all the available parameter types and the variables made
-# available to your script.  If you are passing in string parameters from users
-# or untrusted sources, we advise using escaped versions of the variables to
-# prevent injection attacks.
+# for a reference containing all the available parameter types, and what
+# variables are made available to your script.  If you are passing in string
+# parameters from user input or other untrusted sources, we advise using escaped
+# versions of the variables to prevent injection attacks.
 #
 # Links:
 # * Workflows documentation: https://civis.zendesk.com/hc/en-us/articles/115004172983-Workflows-Basics
@@ -37,8 +38,8 @@ workflow:
       input:
         # SQL scripts always require the IDs of the remote host and the credential
         # you are using to connect to it.
-        remote_host_id: 0  # check https://api.civisanalytics.com/databases
-        credential_id: 0   # check https://platform.civisanalytics.com/credentials
+        remote_host_id: 0  # get it from https://api.civisanalytics.com/databases
+        credential_id: 0   # get it from https://platform.civisanalytics.com/credentials
         params:  # This is not an exhaustive list of param types - see the script parameter reference for more
           - name: my_boolean
             type: bool
@@ -58,11 +59,16 @@ workflow:
           my_custom_credential: 0  # ID of the credential
         sql: |
           SELECT 1;
+
           -- Variables enclosed in double curly brackets will be replaced with the parameter values.
           -- my_boolean: {{my_boolean}}
           -- my_integer: {{my_integer}}
           -- my_float: {{my_float}}
-          -- my_string: {{my_string.literal}}
+
+          -- To prevent SQL injection attacks, you can get escaped versions of string parameters.
+          -- {{my_string.literal}} wraps the string in single quotes, changing single quotes in the string to double quotes.
+          -- {{my_string.identifier}} is in a format that is safe to be used as a Redshift identifier.
+
           -- my_custom_credential: {{my_custom_credential.username}} {{my_custom_credential.password}}
       on-success:
         - container_script
@@ -111,6 +117,7 @@ workflow:
           echo "my_boolean = $MY_BOOLEAN"
           echo "my_integer = $MY_INTEGER"
           echo "my_float = $MY_FLOAT"
+          # To prevent command injection attacks, you can get shell-escaped versions of string parameters.
           echo "my_string = $MY_STRING_SHELL_ESCAPED"
           echo "my_file is at $MY_FILE_URL"
           # It is generally not advisable to log your credentials.
@@ -213,11 +220,14 @@ workflow:
           # Parameter values are added to your container as environment variables.
           # See the script params reference for a full list.
 
+          # Type conversion are necessary.
           my_boolean <- as.logical(Sys.getenv('MY_BOOLEAN'))
           my_integer <- as.numeric(Sys.getenv('MY_INTEGER'))
           my_float <- as.numeric(Sys.getenv('MY_FLOAT'))
+
           my_string <- Sys.getenv('MY_STRING')
           my_file_url <- Sys.getenv('MY_FILE_URL')
+
           my_custom_credential_username <- Sys.getenv('MY_CUSTOM_CREDENTIAL_USERNAME')
           my_custom_credential_password <- Sys.getenv('MY_CUSTOM_CREDENTIAL_PASSWORD')
           my_aws_credential_access_key_id <- Sys.getenv('MY_AWS_CREDENTIAL_ACCESS_KEY_ID')

--- a/script_parameters.yml
+++ b/script_parameters.yml
@@ -18,15 +18,15 @@
 #
 # Inside your script, parameter values are made available via templating (for
 # SQL scripts) or via environment variables (for Container, Python, and R
-# scripts).  See https://civis.zendesk.com/hc/en-us/articles/360001579592-Configuring-Scripts-via-the-Civis-API
-# for a reference containing all the available parameter types, and what
-# variables are made available to your script.  If you are passing in string
-# parameters from user input or other untrusted sources, we advise using escaped
-# versions of the variables to prevent injection attacks.
+# scripts).  See the Script parameter reference linked below for a reference
+# containing all the available parameter types, and what variables are made
+# available to your script.  If you are passing in string parameters from user
+# input or other untrusted sources, we advise using escaped versions of the
+# variables to prevent injection attacks.
 #
 # Links:
-# * Workflows documentation: https://civis.zendesk.com/hc/en-us/articles/115004172983-Workflows-Basics
-# * Script parameter reference: https://civis.zendesk.com/hc/en-us/articles/360001579592-Configuring-Scripts-via-the-Civis-API
+# * Workflows documentation (requires Platform login): https://civis.zendesk.com/hc/en-us/articles/115004172983-Workflows-Basics
+# * Script parameter reference (requires Platform login): https://civis.zendesk.com/hc/en-us/articles/360001579592-Configuring-Scripts-via-the-Civis-API
 # * Mistral domain specific language reference: https://docs.openstack.org/mistral/latest/user/wf_lang_v2.html
 # * YAML syntax: https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html
 

--- a/script_parameters.yml
+++ b/script_parameters.yml
@@ -35,27 +35,30 @@ workflow:
     sql_script:
       action: civis.scripts.sql
       input:
-        remote_host_id: 0
-        credential_id: 0
-        params:
+        # SQL scripts always require the IDs of the remote host and the credential
+        # you are using to connect to it.
+        remote_host_id: 0  # check https://api.civisanalytics.com/databases
+        credential_id: 0   # check https://platform.civisanalytics.com/credentials
+        params:  # This is not an exhaustive list of param types - see the script parameter reference for more
           - name: my_boolean
             type: bool
-            default: true
           - name: my_integer
             type: integer
-            default: 1234
           - name: my_float
             type: float
-            default: 0.1234
           - name: my_string
             type: string
-            default: this is a string
           - name: my_custom_credential
             type: credential_custom
         arguments:
-          my_custom_credential: 0
+          my_boolean: true
+          my_integer: 1234
+          my_float: 0.1234
+          my_string: this is a string
+          my_custom_credential: 0  # ID of the credential
         sql: |
           SELECT 1;
+          -- Variables enclosed in double curly brackets will be replaced with the parameter values.
           -- my_boolean: {{my_boolean}}
           -- my_integer: {{my_integer}}
           -- my_float: {{my_float}}
@@ -63,15 +66,20 @@ workflow:
           -- my_custom_credential: {{my_custom_credential.username}} {{my_custom_credential.password}}
       on-success:
         - container_script
+
     container_script:
       action: civis.scripts.container
       input:
         docker_image_name: civisanalytics/datascience-python
+        docker_image_tag: latest
         required_resources:
           cpu: 256
           memory: 512
           disk_space: 1
         params:
+          # Optionally, you can specify the parameter values in the `params` list
+          # instead of in the `arguments` hash, by using the `default` key.  But
+          # this does not work for credential parameters.
           - name: my_boolean
             type: bool
             default: true
@@ -86,7 +94,7 @@ workflow:
             default: this is a string
           - name: my_file
             type: file
-            default: 0
+            default: 0  # ID of the file
           - name: my_custom_credential
             type: credential_custom
           - name: my_aws_credential
@@ -94,20 +102,24 @@ workflow:
           - name: my_db_credential
             type: credential_redshift
         arguments:
-          my_custom_credential: 0
+          my_custom_credential: 0  # ID of the credential
           my_aws_credential: 0
           my_db_credential: 0
         docker_command: |
+          # Parameter values are added to your container as environment variables.
+          # See the script params reference for a full list.
           echo "my_boolean = $MY_BOOLEAN"
           echo "my_integer = $MY_INTEGER"
           echo "my_float = $MY_FLOAT"
           echo "my_string = $MY_STRING_SHELL_ESCAPED"
           echo "my_file is at $MY_FILE_URL"
-          # echo "my_custom_credential has username $MY_CUSTOM_CREDENTIAL_USERNAME, password $MY_CUSTOM_CREDENTIAL_PASSWORD"
-          # echo "my_aws_credential has access key id $MY_AWS_CREDENTIAL_ACCESS_KEY_ID, secret key $MY_AWS_CREDENTIAL_SECRET_ACCESS_KEY"
-          # echo "my_db_credential has username $MY_DB_CREDENTIAL_USERNAME, password $MY_DB_CREDENTIAL_PASSWORD"
+          # It is generally not advisable to log your credentials.
+          # my_custom_credential generates $MY_CUSTOM_CREDENTIAL_USERNAME, $MY_CUSTOM_CREDENTIAL_PASSWORD
+          # my_aws_credential generates $MY_AWS_CREDENTIAL_ACCESS_KEY_ID, $MY_AWS_CREDENTIAL_SECRET_ACCESS_KEY
+          # my_db_credential generates $MY_DB_CREDENTIAL_USERNAME, $MY_DB_CREDENTIAL_PASSWORD
       on-success:
         - python_script
+
     python_script:
       action: civis.scripts.python3
       input:
@@ -116,6 +128,9 @@ workflow:
           memory: 512
           disk_space: 1
         params:
+          # Optionally, you can specify the parameter values in the `params` list
+          # instead of in the `arguments` hash, by using the `default` key.  But
+          # this does not work for credential parameters.
           - name: my_boolean
             type: bool
             default: true
@@ -130,7 +145,7 @@ workflow:
             default: this is a string
           - name: my_file
             type: file
-            default: 0
+            default: 0  # ID of the file
           - name: my_custom_credential
             type: credential_custom
           - name: my_aws_credential
@@ -138,12 +153,16 @@ workflow:
           - name: my_db_credential
             type: credential_redshift
         arguments:
-          my_custom_credential: 0
+          my_custom_credential: 0  # ID of the credential
           my_aws_credential: 0
           my_db_credential: 0
         source: |
+          # Parameter values are added to your container as environment variables.
+          # See the script params reference for a full list.
+
           import os
 
+          # Type conversions are necessary.  Unfortunately, `bool()` does not work here.
           my_boolean = os.environ['MY_BOOLEAN'] == 'true'
           my_integer = int(os.environ['MY_INTEGER'])
           my_float = float(os.environ['MY_FLOAT'])
@@ -156,6 +175,7 @@ workflow:
           my_db_credential = (os.environ['MY_DB_CREDENTIAL_USERNAME'], os.environ['MY_DB_CREDENTIAL_PASSWORD'])
       on-success:
         - r_script
+
     r_script:
       action: civis.scripts.r
       input:
@@ -166,19 +186,14 @@ workflow:
         params:
           - name: my_boolean
             type: bool
-            default: true
           - name: my_integer
             type: integer
-            default: 1234
           - name: my_float
             type: float
-            default: 0.1234
           - name: my_string
             type: string
-            default: this is a string
           - name: my_file
             type: file
-            default: 0
           - name: my_custom_credential
             type: credential_custom
           - name: my_aws_credential
@@ -186,10 +201,18 @@ workflow:
           - name: my_db_credential
             type: credential_redshift
         arguments:
-          my_custom_credential: 0
+          my_boolean: true
+          my_integer: 1234
+          my_float: 0.1234
+          my_string: this is a string
+          my_file: 0               # ID of the file
+          my_custom_credential: 0  # ID of the credential
           my_aws_credential: 0
           my_db_credential: 0
         source: |
+          # Parameter values are added to your container as environment variables.
+          # See the script params reference for a full list.
+
           my_boolean <- as.logical(Sys.getenv('MY_BOOLEAN'))
           my_integer <- as.numeric(Sys.getenv('MY_INTEGER'))
           my_float <- as.numeric(Sys.getenv('MY_FLOAT'))
@@ -203,9 +226,14 @@ workflow:
           my_db_credential_password <- Sys.getenv('MY_DB_CREDENTIAL_PASSWORD')
       on-success:
         - custom_script
+
     custom_script:
       action: civis.scripts.custom
       input:
-        from_template_id: 0
+        # Custom scripts are built off of templates, which already define the
+        # `params` list, so all you need to provide is the `arguments` hash.
+        # For this example we'll pretend that the template has a string parameter
+        # called `my_string`.
+        from_template_id: 0  # ID of the template backing your custom script
         arguments:
-          branch_namme: blah
+          my_string: this is a string

--- a/sql_scripts.yml
+++ b/sql_scripts.yml
@@ -6,7 +6,7 @@
 # See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/train/user/wf_lang_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL

--- a/task_defaults.yml
+++ b/task_defaults.yml
@@ -6,7 +6,7 @@
 # See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/train/user/wf_lang_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL

--- a/variable_blocks.yml
+++ b/variable_blocks.yml
@@ -6,7 +6,7 @@
 # See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/train/user/wf_lang_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL

--- a/with_items.yml
+++ b/with_items.yml
@@ -6,7 +6,7 @@
 # See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/train/user/wf_lang_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL

--- a/with_items_dict.yml
+++ b/with_items_dict.yml
@@ -6,7 +6,7 @@
 # See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/train/user/wf_lang_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL

--- a/yaml_variables.yml
+++ b/yaml_variables.yml
@@ -6,7 +6,7 @@
 # See this website, https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html,
 # for an introduction to YAML.
 #
-# See the Mistral documentation, https://docs.openstack.org/mistral/pike/user/dsl_v2.html,
+# See the Mistral documentation, https://docs.openstack.org/mistral/train/user/wf_lang_v2.html,
 # for a description of the Mistral DSL.
 
 version: '2.0'  # you always need this key to specify version 2 of the mistral DSL


### PR DESCRIPTION
Some users have requested examples for passing script parameters into scripts in a workflow, so I've written an example workflow that demonstrates defining the parameters and their values, and using those parameters within the script, for all the major script types.

I've also tried to update the README, and update the Mistral DSL documentation links to those of the Mistral version we're now on.