### PR TITLE
use two DB credentials

### DIFF
--- a/db_syncs.yml
+++ b/db_syncs.yml
@@ -14,7 +14,9 @@
 version: "2.0"
 workflow:
   input:
-    - database_credential_id: 11722  # Your database credential (can be found in Platform Credentials)
+  # Your database credentials (can be found in Platform Credentials)
+    - source_database_credential_id: 11722  
+    - destination_database_credential_id: 12345
 
     # Source database parameters
     - source_remote_host_id: 89  # The source database ID

--- a/db_syncs.yml
+++ b/db_syncs.yml
@@ -42,10 +42,10 @@ workflow:
         # Required
         is_outbound: false
         source:
-          credentialID: <% $.database_credential_id %>
+          credentialID: <% $.source_database_credential_id %>
           remoteHostId: <% $.source_remote_host_id %>
         destination:
-          credentialID: <% $.database_credential_id %>
+          credentialID: <% $.destination_database_credential_id %>
           remoteHostId: <% $.destination_remote_host_id %>
 
         # List of tables to be transferred


### PR DESCRIPTION
Use two credentials for the db syncs since that's a more common use case. 