### PR TITLE
Add workflow to monitor long-running Tableau refresh jobs

### DIFF
--- a/tableau_refresh_polling.yml
+++ b/tableau_refresh_polling.yml
@@ -1,0 +1,84 @@
+# This workflow is built to monitor long-running Tableau refresh jobs. It is composed of 3 tasks:
+#
+# 1. Task to kick off the Tableau refresh
+# 2. Task to poll for status of the refresh job, until it reaches a completed state
+# 3. Task to check the final status of the refresh job, and fail or succeed the whole workflow accordingly
+#
+# The existence of the 3rd task is necessary to allow the 2nd task to stop polling whenever a final status is reached,
+# whether that is a success or a failure. If the 2nd task were to error on failure, then the workflow would keep polling
+# unnecessarily until the max amount of retries was met.
+
+version: '2.0'
+workflow:
+  input:
+    - report_id:
+  tasks:
+    start_refresh:
+      action: civis.scripts.python3
+      input:
+        name: Refresh Tableau Report
+        source: |
+          import os
+          import json
+          import civis
+          client = civis.APIClient()
+          # Start the refresh
+          refresh_response = client.reports.post_refresh(<% $.report_id %>)
+          print(json.dumps(refresh_response.json(), indent=4))
+          # Save the tableau refresh job ID as a job output, so it can be accessed from the poll_refresh_status task
+          json_value_obj = client.json_values.post(json.dumps(refresh_response.tableau_refresh_job_id), name="Tableau Refresh Job ID")
+          client.scripts.post_python3_runs_outputs(os.environ['CIVIS_JOB_ID'], os.environ['CIVIS_RUN_ID'], 'JSONValue', json_value_obj.id)
+      on-success:
+        - poll_refresh_status
+    poll_refresh_status:
+      action: civis.scripts.python3
+      retry:
+        # Delay between attempts in seconds.
+        # Customize this to suit the refresh you're checking on.
+        # 600 seconds = 10 minutes
+        delay: 600
+        # Number of attempts, not including the first one.
+        # A count of 6 means there are 7 attempts.
+        # 7 attempts * 10 minutes between attempts = 1 hour of job status polling
+        count: 6
+      input:
+        name: Poll Tableau Refresh Job Status
+        source: |
+          import os
+          import json
+          import time
+          import civis
+          client = civis.APIClient()
+          # Fetch tableau job ID from previous job's outputs. Note that JSON outputs always return a list
+          refresh_job_id = <% task(start_refresh).result.outputs.where($.name = 'Tableau Refresh Job ID').value %>[0]
+          resp = client.reports.get_refresh(<% $.report_id %>, refresh_job_id)
+          if resp.status in ['queued', 'running']:
+            raise RuntimeError(f'Refresh job is {resp.status}')
+          else:
+            if resp.error:
+              status_message = f'Job {resp.job_id} {resp.status}. Error: {resp.error}'
+            else:
+              status_message = f'Job {resp.job_id} {resp.status}'
+            print(status_message)
+            # Save the final status as a job output, so it can be accessed from the check status task
+            status_obj = client.json_values.post(json.dumps(resp.status), name="Final Status")
+            message_obj = client.json_values.post(json.dumps(status_message), name="Status Message")
+            client.scripts.post_python3_runs_outputs(os.environ['CIVIS_JOB_ID'], os.environ['CIVIS_RUN_ID'], 'JSONValue', status_obj.id)
+            client.scripts.post_python3_runs_outputs(os.environ['CIVIS_JOB_ID'], os.environ['CIVIS_RUN_ID'], 'JSONValue', message_obj.id)
+      on-success:
+        - check_final_status
+    check_final_status:
+      action: civis.scripts.python3
+      input:
+        name: Check Tableau Refresh Job Final Status
+        source: |
+          import civis
+          client = civis.APIClient()
+          # Fetch final status & message from previous job's outputs. Note that JSON outputs always return a list
+          final_status = <% task(poll_refresh_status).result.outputs.where($.name = 'Final Status').value %>[0]
+          status_message = <% task(poll_refresh_status).result.outputs.where($.name = 'Status Message').value %>[0]
+          # Raise an error if the job failed, otherwise just print the status message
+          if final_status == 'succeeded':
+              print(f'{status_message}')
+          else:
+            raise RuntimeError(f'{status_message}')

--- a/tableau_refresh_polling.yml
+++ b/tableau_refresh_polling.yml
@@ -46,11 +46,10 @@ workflow:
         source: |
           import os
           import json
-          import time
           import civis
           client = civis.APIClient()
-          # Fetch tableau job ID from previous job's outputs. Note that JSON outputs always return a list
-          refresh_job_id = <% task(start_refresh).result.outputs.where($.name = 'Tableau Refresh Job ID').value %>[0]
+          # Fetch tableau job ID from previous job's outputs
+          refresh_job_id = <% task(start_refresh).result.outputs.where($.name = 'Tableau Refresh Job ID').first().value %>
           resp = client.reports.get_refresh(<% $.report_id %>, refresh_job_id)
           if resp.status in ['queued', 'running']:
             raise RuntimeError(f'Refresh job is {resp.status}')
@@ -74,11 +73,11 @@ workflow:
         source: |
           import civis
           client = civis.APIClient()
-          # Fetch final status & message from previous job's outputs. Note that JSON outputs always return a list
-          final_status = <% task(poll_refresh_status).result.outputs.where($.name = 'Final Status').value %>[0]
-          status_message = <% task(poll_refresh_status).result.outputs.where($.name = 'Status Message').value %>[0]
+          # Fetch final status & message from previous job's outputs
+          final_status = <% task(poll_refresh_status).result.outputs.where($.name = 'Final Status').first().value %>
+          status_message = <% task(poll_refresh_status).result.outputs.where($.name = 'Status Message').first().value %>
           # Raise an error if the job failed, otherwise just print the status message
           if final_status == 'succeeded':
-              print(f'{status_message}')
+            print(status_message)
           else:
             raise RuntimeError(f'{status_message}')

--- a/tableau_refresh_polling.yml
+++ b/tableau_refresh_polling.yml
@@ -2,11 +2,15 @@
 #
 # 1. Task to kick off the Tableau refresh
 # 2. Task to poll for status of the refresh job, until it reaches a completed state
-# 3. Task to check the final status of the refresh job, and fail or succeed the whole workflow accordingly
+# 3. Task to check the final state of the refresh job, and fail or succeed the whole workflow accordingly
 #
-# The existence of the 3rd task is necessary to allow the 2nd task to stop polling whenever a final status is reached,
+# The existence of the 3rd task is necessary to allow the 2nd task to stop polling whenever a final state is reached,
 # whether that is a success or a failure. If the 2nd task were to error on failure, then the workflow would keep polling
 # unnecessarily until the max amount of retries was met.
+#
+# The scripts in this example are inline, one-off scripts created by the civis.scripts.python3 action to
+# facilitate showing all the necessary code in a single file. However, users may prefer to create
+# free-standing scripts, run with the civis.run_job action, to make it easier to see refresh trends over time.
 
 version: '2.0'
 workflow:
@@ -16,7 +20,8 @@ workflow:
     start_refresh:
       action: civis.scripts.python3
       input:
-        name: Refresh Tableau Report
+        name: Refresh Tableau Report (ID:<% $.report_id %>)
+        hidden: true # hide from index pages
         source: |
           import os
           import json
@@ -25,12 +30,12 @@ workflow:
           # Start the refresh
           refresh_response = client.reports.post_refresh(<% $.report_id %>)
           print(json.dumps(refresh_response.json(), indent=4))
-          # Save the tableau refresh job ID as a job output, so it can be accessed from the poll_refresh_status task
+          # Save the tableau refresh job ID as a job output, so it can be accessed from the poll_refresh_state task
           json_value_obj = client.json_values.post(json.dumps(refresh_response.tableau_refresh_job_id), name="Tableau Refresh Job ID")
           client.scripts.post_python3_runs_outputs(os.environ['CIVIS_JOB_ID'], os.environ['CIVIS_RUN_ID'], 'JSONValue', json_value_obj.id)
       on-success:
-        - poll_refresh_status
-    poll_refresh_status:
+        - poll_refresh_state
+    poll_refresh_state:
       action: civis.scripts.python3
       retry:
         # Delay between attempts in seconds.
@@ -39,45 +44,47 @@ workflow:
         delay: 600
         # Number of attempts, not including the first one.
         # A count of 6 means there are 7 attempts.
-        # 7 attempts * 10 minutes between attempts = 1 hour of job status polling
+        # 7 attempts * 10 minutes between attempts = 1 hour of job state polling
         count: 6
       input:
-        name: Poll Tableau Refresh Job Status
+        name: Poll Tableau Refresh Job State (Report ID:<% $.report_id %>)
+        hidden: true # hide from index pages
         source: |
           import os
           import json
           import civis
           client = civis.APIClient()
           # Fetch tableau job ID from previous job's outputs
-          refresh_job_id = <% task(start_refresh).result.outputs.where($.name = 'Tableau Refresh Job ID').first().value %>
+          refresh_job_id = <% task(start_refresh).result.outputs.where($.name = 'Tableau Refresh Job ID').value %>[0]
           resp = client.reports.get_refresh(<% $.report_id %>, refresh_job_id)
-          if resp.status in ['queued', 'running']:
-            raise RuntimeError(f'Refresh job is {resp.status}')
+          if resp.state in ['queued', 'running']:
+            raise RuntimeError(f'Refresh job is {resp.state}')
           else:
             if resp.error:
-              status_message = f'Job {resp.job_id} {resp.status}. Error: {resp.error}'
+              state_message = f'Job {resp.job_id} {resp.state}. Error: {resp.error}'
             else:
-              status_message = f'Job {resp.job_id} {resp.status}'
-            print(status_message)
-            # Save the final status as a job output, so it can be accessed from the check status task
-            status_obj = client.json_values.post(json.dumps(resp.status), name="Final Status")
-            message_obj = client.json_values.post(json.dumps(status_message), name="Status Message")
-            client.scripts.post_python3_runs_outputs(os.environ['CIVIS_JOB_ID'], os.environ['CIVIS_RUN_ID'], 'JSONValue', status_obj.id)
+              state_message = f'Job {resp.job_id} {resp.state}'
+            print(state_message)
+            # Save the final state as a job output, so it can be accessed from the check state task
+            state_obj = client.json_values.post(json.dumps(resp.state), name="Final State")
+            message_obj = client.json_values.post(json.dumps(state_message), name="State Message")
+            client.scripts.post_python3_runs_outputs(os.environ['CIVIS_JOB_ID'], os.environ['CIVIS_RUN_ID'], 'JSONValue', state_obj.id)
             client.scripts.post_python3_runs_outputs(os.environ['CIVIS_JOB_ID'], os.environ['CIVIS_RUN_ID'], 'JSONValue', message_obj.id)
       on-success:
-        - check_final_status
-    check_final_status:
+        - check_final_state
+    check_final_state:
       action: civis.scripts.python3
       input:
-        name: Check Tableau Refresh Job Final Status
+        name: Check Tableau Refresh Job Final State (Report ID:<% $.report_id %>)
+        hidden: true # hide from index pages
         source: |
           import civis
           client = civis.APIClient()
-          # Fetch final status & message from previous job's outputs
-          final_status = <% task(poll_refresh_status).result.outputs.where($.name = 'Final Status').first().value %>
-          status_message = <% task(poll_refresh_status).result.outputs.where($.name = 'Status Message').first().value %>
-          # Raise an error if the job failed, otherwise just print the status message
-          if final_status == 'succeeded':
-            print(status_message)
+          # Fetch final state & message from previous job's outputs
+          final_state = <% task(poll_refresh_state).result.outputs.where($.name = 'Final State').value %>[0]
+          state_message = <% task(poll_refresh_state).result.outputs.where($.name = 'State Message').value %>[0]
+          # Raise an error if the job failed, otherwise just print the state message
+          if final_state == 'succeeded':
+            print(state_message)
           else:
-            raise RuntimeError(f'{status_message}')
+            raise RuntimeError(f'{state_message}')


### PR DESCRIPTION
Add an example workflow for monitoring long-running Tableau refresh jobs. 

This example will be useful for those who want to know if their refresh job succeeded or not without running a second script (and using compute resources) for the entire duration of the refresh job. Each individual job in this workflow will only run for 10-15 seconds at a time.